### PR TITLE
Remove angle brace, allow link formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Tehtävä #0:
 Päivitä updateImage-funktiota niin että sivulla näytetään eri kuvat.
 
 Tehtävä #1:
-Päivitä funktiota niin että se näyttää [alertin]](https://www.w3schools.com/jsref/met_win_alert.asp) (huomiolaatikon) käyttäjälle kun kuva vaihtuu.
+Päivitä funktiota niin että se näyttää [alertin](https://www.w3schools.com/jsref/met_win_alert.asp) (huomiolaatikon) käyttäjälle kun kuva vaihtuu.
 
 Tehtävä #2:
 Lisää sivulle toinen painike, jota klikkaamalla käyttäjä [ohjataan toiselle sivulle](https://www.w3schools.com/howto/howto_js_redirect_webpage.asp).


### PR DESCRIPTION
Removes a superfluous angle brace. This fixes the link formatting.
<img width="575" alt="Screenshot 2022-04-06 at 10 26 58" src="https://user-images.githubusercontent.com/35032643/161919393-9c00736d-798f-49e7-9dc1-81120fe54f9b.png">

