### PR TITLE
Remove duplicate declaration of p style

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -12,10 +12,6 @@ section {
   margin: 3rem;
 }
 
-p {
-  color: #180044;
-}
-
 header {
   background-color: #000000;
 }


### PR DESCRIPTION
`p` is double-declared, both on lines 15-17 and 34-37. This is probably not intended. This PR removes the first declaration.